### PR TITLE
CLI improvements

### DIFF
--- a/src/kiwitracker/sample_reader.py
+++ b/src/kiwitracker/sample_reader.py
@@ -418,29 +418,71 @@ def main():
         type=int,
         help='Number of samples to read when "-o/--outfile" is specified',
     )
-    p.add_argument(
+
+    s_group = p.add_argument_group('Sampling')
+    s_group.add_argument(
         '-c', '--chunk-size',
         dest='chunk_size',
         type=int,
-        default=SampleConfig().read_size,
-        help='Chunk size for sdr.read_samples',
+        default=SampleConfig.read_size,
+        help='Chunk size for sdr.read_samples (default: %(default)s)',
     )
+    s_group.add_argument(
+        '-s', '--sample-rate', dest='sample_rate', type=float,
+        default=SampleConfig.sample_rate,
+        help='SDR sample rate (default: %(default)s)',
+    )
+    s_group.add_argument(
+        '--center-freq', dest='center_freq', type=float,
+        default=SampleConfig.center_freq,
+        help='SDR center frequency (default: %(default)s)',
+    )
+    s_group.add_argument(
+        '-g', '--gain', dest='gain', type=float,
+        default=SampleConfig.gain,
+        help='SDR gain (default: %(default)s)',
+    )
+
+    p_group = p.add_argument_group('Processing')
+    p_group.add_argument(
+        '--carrier', dest='carrier', type=float,
+        default=ProcessConfig.carrier_freq,
+        help='Carrier frequency to process (default: %(default)s)',
+    )
+
     args = p.parse_args()
+
+    sample_config = SampleConfig(
+        sample_rate=args.sample_rate, center_freq=args.center_freq,
+        gain=args.gain, read_size=args.chunk_size,
+    )
+    process_config = ProcessConfig(
+        sample_config=sample_config, carrier_freq=args.carrier,
+    )
+
     if args.infile is not None:
-        run_from_disk(args.infile)
+        run_from_disk(
+            process_config=process_config,
+            filename=args.infile,
+        )
     elif args.outfile is not None:
         assert args.max_samples is not None
         asyncio.run(
-            run_readonly(args.outfile, args.chunk_size, args.max_samples)
+            run_readonly(
+                sample_config=sample_config,
+                filename=args.outfile,
+                max_samples=args.max_samples,
+            )
         )
     else:
         asyncio.run(
-            run_main(args.chunk_size)
+            run_main(sample_config=sample_config, process_config=process_config)
         )
 
 
-async def run_readonly(outfile: str, chunk_size: int, max_samples: int):
-    nrows = max_samples // chunk_size
+async def run_readonly(sample_config: SampleConfig, filename: str, max_samples: int):
+    chunk_size = sample_config.read_size
+    nrows = max_samples // sample_config.read_size
     if nrows * chunk_size < max_samples:
         nrows += 1
     samples = np.zeros((nrows, chunk_size), dtype=np.complex128)
@@ -461,13 +503,11 @@ async def run_readonly(outfile: str, chunk_size: int, max_samples: int):
             if count >= max_samples:
                 break
     samples = samples.flatten()[:max_samples]
-    np.save(outfile, samples)
+    np.save(filename, samples)
 
 
-def run_from_disk(filename):
+def run_from_disk(process_config: ProcessConfig, filename: str):
     samples = np.load(filename)
-    sample_config = SampleConfig()
-    process_config = ProcessConfig(sample_config=sample_config)
     processor = SampleProcessor(process_config)
     for ix in range(0, samples.size, processor.num_samples_to_process ):
         start_time = time.time()
@@ -476,9 +516,7 @@ def run_from_disk(filename):
         print(f" run time is {finish_time-start_time}")
 
 
-async def run_main(chunk_size: int):
-    sample_config = SampleConfig(read_size=chunk_size)
-    process_config = ProcessConfig(sample_config=sample_config)
+async def run_main(sample_config: SampleConfig, process_config: ProcessConfig):
     reader = SampleReader(sample_config)
     processor = SampleProcessor(process_config)
     buffer = SampleBuffer(maxsize=processor.num_samples_to_process * 3)


### PR DESCRIPTION
- Clean up unused arguments
- Allow sampling and processing parameters to be set via command line

Example:

```bash
$ kiwitracker -h
usage: kiwitracker [-h] [-f INFILE] [-o OUTFILE] [-m MAX_SAMPLES] [-c CHUNK_SIZE] [-s SAMPLE_RATE] [--center-freq CENTER_FREQ]
                   [-g GAIN] [--carrier CARRIER]

options:
  -h, --help            show this help message and exit
  -f INFILE, --from-file INFILE
                        Read samples from the given filename and process them
  -o OUTFILE, --outfile OUTFILE
                        Read samples from the device and save to the given filename
  -m MAX_SAMPLES, --max-samples MAX_SAMPLES
                        Number of samples to read when "-o/--outfile" is specified

Sampling:
  -c CHUNK_SIZE, --chunk-size CHUNK_SIZE
                        Chunk size for sdr.read_samples (default: 65536)
  -s SAMPLE_RATE, --sample-rate SAMPLE_RATE
                        SDR sample rate (default: 1024000.0)
  --center-freq CENTER_FREQ
                        SDR center frequency (default: 160270968)
  -g GAIN, --gain GAIN  SDR gain (default: 7.7)

Processing:
  --carrier CARRIER     Carrier frequency to process (default: 160707760)
```