### PR TITLE
Add ability to read fc32 and sc8 input files

### DIFF
--- a/src/kiwitracker/sample_reader.py
+++ b/src/kiwitracker/sample_reader.py
@@ -578,12 +578,20 @@ def run_from_disk(process_config: ProcessConfig, filename: str):
         samples = samples.astype(np.complex64)
 
     processor = SampleProcessor(process_config)
+
+    # Organize input samples into chunks, resize handles padding the end with zeroes
+    # Better would be to only read single chunks from the file
+    chunk_len = processor.num_samples_to_process
+    n_chunks = np.floor(samples.size/chunk_len).astype(int)
+    samples.resize(n_chunks, chunk_len)
+
     start_time = time.time()
-    for ix in range(0, samples.size, processor.num_samples_to_process ):
-    
-        processor.process(samples[ix:ix+processor.num_samples_to_process])
+
+    for chunk in samples:
+        processor.process(chunk)
+
     finish_time = time.time()
-    print(f" run time is {finish_time-start_time}")
+    print(f" run time is {finish_time-start_time:.2f}")
 
 
 async def run_main(sample_config: SampleConfig, process_config: ProcessConfig):

--- a/src/kiwitracker/sample_reader.py
+++ b/src/kiwitracker/sample_reader.py
@@ -546,8 +546,37 @@ async def run_readonly(sample_config: SampleConfig, filename: str, max_samples: 
 
 
 def run_from_disk(process_config: ProcessConfig, filename: str):
-    #samples = np.load(filename, allow_pickle=True)
-    samples = np.fromfile(filename)
+    file_extension = os.path.splitext(filename)[1]
+    file_dtype = np.complex64
+
+    match file_extension:
+        case ".fc32":
+            file_dtype = np.complex64
+        case ".sc8":
+            file_dtype = np.uint8
+        case ".s8":
+            file_dtype = np.uint8
+        case ".npy":
+            # read the sample data type from the first sample in the file
+            file_dtype = type(np.load(filename, mmap_mode='r')[0])
+        case _:
+            print(f'Unknown file extension {file_extension}. Rename to one of .fc32, .sc8, or .npy')
+            return
+    
+    print(f'Loading samples from {filename} with data type {file_dtype}')
+    samples = np.fromfile(filename, dtype=np.complex64)
+    print(f'{len(samples)} samples loaded')
+
+    # Convert unsigned 8 bit samples to 32 bit floats and complex
+    if file_dtype == np.uint8:
+        iq = samples.astype(np.float32).view(np.complex64)
+        iq /= 127.5
+        iq -= (1 + 1j)
+        samples = iq.copy()
+    
+    if file_dtype == np.complex128:
+        samples = samples.astype(np.complex64)
+
     processor = SampleProcessor(process_config)
     start_time = time.time()
     for ix in range(0, samples.size, processor.num_samples_to_process ):


### PR DESCRIPTION
This PR adds a feature and fixes an issue. The first commit adds the ability to input files with sc8 and fc32 formats while keeping (almost certainly) the ability to read the numpy save format .npy.

Second, it changes the way the samples in the file are sliced to pass to the sample processor. Previously if the length of the input samples was not an exact multiple of the chunk size there would be an error thrown. The new loop resizes the input samples to the chunk sizes.